### PR TITLE
feat(workflow): heartbeat-based zombie detection and auto-resume

### DIFF
--- a/frontend/src/stores/taskStore.js
+++ b/frontend/src/stores/taskStore.js
@@ -20,6 +20,38 @@ const useTaskStore = create((set, get) => ({
     });
   },
 
+  // Load persisted tasks from API response (on page reload)
+  loadPersistedTasks: (workflowId, tasks) => {
+    if (!tasks || tasks.length === 0) return;
+
+    const { tasksByWorkflow } = get();
+    const tasksMap = {};
+
+    for (const task of tasks) {
+      tasksMap[task.id] = {
+        id: task.id,
+        name: task.name,
+        phase: task.phase,
+        status: task.status,
+        cli: task.cli,
+        model: task.model,
+        tokens_in: task.tokens_in,
+        tokens_out: task.tokens_out,
+        cost_usd: task.cost_usd,
+        error: task.error,
+        started_at: task.started_at,
+        completed_at: task.completed_at,
+      };
+    }
+
+    set({
+      tasksByWorkflow: {
+        ...tasksByWorkflow,
+        [workflowId]: tasksMap,
+      },
+    });
+  },
+
   selectTask: (taskId) => {
     set({ selectedTaskId: taskId });
   },

--- a/frontend/src/stores/workflowStore.js
+++ b/frontend/src/stores/workflowStore.js
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { workflowApi } from '../lib/api';
 import useAgentStore from './agentStore';
+import useTaskStore from './taskStore';
 
 const useWorkflowStore = create((set, get) => ({
   // State
@@ -31,6 +32,11 @@ const useWorkflowStore = create((set, get) => ({
       if (activeWorkflow?.agent_events && activeWorkflow.agent_events.length > 0) {
         useAgentStore.getState().loadPersistedEvents(activeWorkflow.id, activeWorkflow.agent_events);
       }
+
+      // Load persisted tasks for page reload recovery
+      if (activeWorkflow?.tasks && activeWorkflow.tasks.length > 0) {
+        useTaskStore.getState().loadPersistedTasks(activeWorkflow.id, activeWorkflow.tasks);
+      }
     } catch (error) {
       // No active workflow is not an error
       if (!error.message.includes('not found')) {
@@ -53,6 +59,11 @@ const useWorkflowStore = create((set, get) => ({
       // Load persisted agent events for page reload recovery
       if (workflow.agent_events && workflow.agent_events.length > 0) {
         useAgentStore.getState().loadPersistedEvents(id, workflow.agent_events);
+      }
+
+      // Load persisted tasks for page reload recovery
+      if (workflow.tasks && workflow.tasks.length > 0) {
+        useTaskStore.getState().loadPersistedTasks(id, workflow.tasks);
       }
 
       return workflow;

--- a/internal/adapters/cli/base.go
+++ b/internal/adapters/cli/base.go
@@ -158,7 +158,7 @@ func (b *BaseAdapter) ExecuteCommand(ctx context.Context, args []string, stdin, 
 		timeout = b.config.Timeout
 	}
 	if timeout == 0 {
-		timeout = 5 * time.Minute
+		timeout = 3 * time.Hour
 	}
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -428,7 +428,7 @@ func (b *BaseAdapter) ExecuteWithStreaming(ctx context.Context, adapterName stri
 		actualTimeout = b.config.Timeout
 	}
 	if actualTimeout == 0 {
-		actualTimeout = 5 * time.Minute
+		actualTimeout = 3 * time.Hour
 	}
 
 	// Emit started event with command info and timeout
@@ -467,7 +467,7 @@ func (b *BaseAdapter) executeWithJSONStreaming(
 		timeout = b.config.Timeout
 	}
 	if timeout == 0 {
-		timeout = 5 * time.Minute
+		timeout = 3 * time.Hour
 	}
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -724,7 +724,7 @@ func (b *BaseAdapter) executeWithLogFileStreaming(
 		timeout = b.config.Timeout
 	}
 	if timeout == 0 {
-		timeout = 5 * time.Minute
+		timeout = 3 * time.Hour
 	}
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/internal/adapters/cli/comprehensive_test.go
+++ b/internal/adapters/cli/comprehensive_test.go
@@ -669,27 +669,27 @@ func TestDefaultConfigAllAdapters(t *testing.T) {
 		{
 			name:        "claude",
 			wantPath:    "claude",
-			wantTimeout: 5 * time.Minute,
+			wantTimeout: 0, // Defer to phase timeout
 		},
 		{
 			name:        "gemini",
 			wantPath:    "gemini",
-			wantTimeout: 5 * time.Minute,
+			wantTimeout: 0, // Defer to phase timeout
 		},
 		{
 			name:        "copilot",
 			wantPath:    "copilot",
-			wantTimeout: 5 * time.Minute,
+			wantTimeout: 0, // Defer to phase timeout
 		},
 		{
 			name:        "codex",
 			wantPath:    "codex",
-			wantTimeout: 5 * time.Minute,
+			wantTimeout: 0, // Defer to phase timeout
 		},
 		{
 			name:        "unknown",
 			wantPath:    "",
-			wantTimeout: 5 * time.Minute,
+			wantTimeout: 0, // Defer to phase timeout
 		},
 	}
 

--- a/internal/adapters/cli/registry.go
+++ b/internal/adapters/cli/registry.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
-	"time"
 
 	"github.com/hugo-lorenzo-mato/quorum-ai/internal/config"
 	"github.com/hugo-lorenzo-mato/quorum-ai/internal/core"
@@ -285,37 +284,38 @@ func (r *Registry) Clear() {
 // the config file (.quorum/config.yaml).
 // Temperature and max_tokens are intentionally omitted - let each CLI
 // use its optimized defaults for coding tasks.
+// Timeout is 0 to defer to phase timeout from ExecuteOptions.
 func defaultConfig(name string) AgentConfig {
 	defaults := map[string]AgentConfig{
 		"claude": {
 			Name:    "claude",
 			Path:    "claude",
 			Model:   "", // NO default - must be configured or CLI uses its default
-			Timeout: 5 * time.Minute,
+			Timeout: 0,  // Defer to ExecuteOptions.Timeout (phase timeout)
 		},
 		"gemini": {
 			Name:    "gemini",
 			Path:    "gemini",
 			Model:   "", // NO default - must be configured or CLI uses its default
-			Timeout: 5 * time.Minute,
+			Timeout: 0,  // Defer to ExecuteOptions.Timeout (phase timeout)
 		},
 		"codex": {
 			Name:    "codex",
 			Path:    "codex",
 			Model:   "", // NO default - must be configured or CLI uses its default
-			Timeout: 5 * time.Minute,
+			Timeout: 0,  // Defer to ExecuteOptions.Timeout (phase timeout)
 		},
 		"copilot": {
 			Name:    "copilot",
 			Path:    "copilot",
 			Model:   "", // NO default - must be configured or CLI uses its default
-			Timeout: 5 * time.Minute,
+			Timeout: 0,  // Defer to ExecuteOptions.Timeout (phase timeout)
 		},
 		"opencode": {
 			Name:    "opencode",
 			Path:    "opencode",
 			Model:   "", // NO default - must be configured or CLI uses its default
-			Timeout: 5 * time.Minute,
+			Timeout: 0,  // Defer to ExecuteOptions.Timeout (phase timeout)
 		},
 	}
 
@@ -325,7 +325,7 @@ func defaultConfig(name string) AgentConfig {
 
 	return AgentConfig{
 		Name:    name,
-		Timeout: 5 * time.Minute,
+		Timeout: 0, // Defer to ExecuteOptions.Timeout (phase timeout)
 	}
 }
 
@@ -417,6 +417,7 @@ func (r *Registry) SetDiagnostics(safeExec *diagnostics.SafeExecutor, dumpWriter
 
 // ConfigureRegistry configures agents in the registry using the application configuration.
 // Agents are configured if their enabled flag is true in the config.
+// Timeout is set to 0 to defer to phase timeout passed via ExecuteOptions.
 func ConfigureRegistry(registry *Registry, cfg *config.AgentsConfig) error {
 	// Configure Claude
 	if cfg.Claude.Enabled {
@@ -424,7 +425,7 @@ func ConfigureRegistry(registry *Registry, cfg *config.AgentsConfig) error {
 			Name:                      "claude",
 			Path:                      cfg.Claude.Path,
 			Model:                     cfg.Claude.Model,
-			Timeout:                   5 * time.Minute,
+			Timeout:                   0, // Defer to ExecuteOptions.Timeout (phase timeout)
 			Phases:                    cfg.Claude.Phases,
 			ReasoningEffort:           cfg.Claude.ReasoningEffort,
 			ReasoningEffortPhases:     cfg.Claude.ReasoningEffortPhases,
@@ -438,7 +439,7 @@ func ConfigureRegistry(registry *Registry, cfg *config.AgentsConfig) error {
 			Name:                      "gemini",
 			Path:                      cfg.Gemini.Path,
 			Model:                     cfg.Gemini.Model,
-			Timeout:                   5 * time.Minute,
+			Timeout:                   0, // Defer to ExecuteOptions.Timeout (phase timeout)
 			Phases:                    cfg.Gemini.Phases,
 			ReasoningEffort:           cfg.Gemini.ReasoningEffort,
 			ReasoningEffortPhases:     cfg.Gemini.ReasoningEffortPhases,
@@ -452,7 +453,7 @@ func ConfigureRegistry(registry *Registry, cfg *config.AgentsConfig) error {
 			Name:                      "codex",
 			Path:                      cfg.Codex.Path,
 			Model:                     cfg.Codex.Model,
-			Timeout:                   5 * time.Minute,
+			Timeout:                   0, // Defer to ExecuteOptions.Timeout (phase timeout)
 			Phases:                    cfg.Codex.Phases,
 			ReasoningEffort:           cfg.Codex.ReasoningEffort,
 			ReasoningEffortPhases:     cfg.Codex.ReasoningEffortPhases,
@@ -466,7 +467,7 @@ func ConfigureRegistry(registry *Registry, cfg *config.AgentsConfig) error {
 			Name:                      "copilot",
 			Path:                      cfg.Copilot.Path,
 			Model:                     cfg.Copilot.Model,
-			Timeout:                   5 * time.Minute,
+			Timeout:                   0, // Defer to ExecuteOptions.Timeout (phase timeout)
 			Phases:                    cfg.Copilot.Phases,
 			ReasoningEffort:           cfg.Copilot.ReasoningEffort,
 			ReasoningEffortPhases:     cfg.Copilot.ReasoningEffortPhases,
@@ -480,7 +481,7 @@ func ConfigureRegistry(registry *Registry, cfg *config.AgentsConfig) error {
 			Name:                      "opencode",
 			Path:                      cfg.OpenCode.Path,
 			Model:                     cfg.OpenCode.Model,
-			Timeout:                   5 * time.Minute,
+			Timeout:                   0, // Defer to ExecuteOptions.Timeout (phase timeout)
 			Phases:                    cfg.OpenCode.Phases,
 			ReasoningEffort:           cfg.OpenCode.ReasoningEffort,
 			ReasoningEffortPhases:     cfg.OpenCode.ReasoningEffortPhases,

--- a/internal/adapters/state/migrations/004_add_heartbeat_columns.sql
+++ b/internal/adapters/state/migrations/004_add_heartbeat_columns.sql
@@ -1,0 +1,17 @@
+-- Migration 004: Add heartbeat columns for zombie detection and auto-resume
+-- Adds columns to track workflow heartbeats and resume attempts
+
+-- Add heartbeat_at column to track last heartbeat timestamp
+ALTER TABLE workflows ADD COLUMN heartbeat_at DATETIME;
+
+-- Add resume_count column to track number of auto-resumes
+ALTER TABLE workflows ADD COLUMN resume_count INTEGER DEFAULT 0;
+
+-- Add max_resumes column to limit auto-resume attempts
+ALTER TABLE workflows ADD COLUMN max_resumes INTEGER DEFAULT 3;
+
+-- Create index for efficient zombie detection queries
+CREATE INDEX IF NOT EXISTS idx_workflows_zombie_detection ON workflows(status, heartbeat_at);
+
+-- Record migration
+INSERT INTO schema_migrations (version, description) VALUES (4, 'Add heartbeat columns for zombie detection');

--- a/internal/api/executor.go
+++ b/internal/api/executor.go
@@ -1,0 +1,261 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/hugo-lorenzo-mato/quorum-ai/internal/control"
+	"github.com/hugo-lorenzo-mato/quorum-ai/internal/core"
+	"github.com/hugo-lorenzo-mato/quorum-ai/internal/events"
+	"github.com/hugo-lorenzo-mato/quorum-ai/internal/service/workflow"
+)
+
+// WorkflowExecutor handles workflow execution and lifecycle management.
+// It centralizes the logic for running, resuming, and tracking workflows,
+// making it available to both the API handlers and the zombie detector.
+type WorkflowExecutor struct {
+	runnerFactory *RunnerFactory
+	stateManager  core.StateManager
+	eventBus      *events.EventBus
+	logger        *slog.Logger
+
+	// Track running workflows to prevent double-execution
+	running sync.Map // map[string]bool
+
+	// Track control planes for pause/resume/cancel
+	controlPlanes sync.Map // map[string]*control.ControlPlane
+
+	// Execution timeout
+	executionTimeout time.Duration
+}
+
+// NewWorkflowExecutor creates a new workflow executor.
+func NewWorkflowExecutor(
+	runnerFactory *RunnerFactory,
+	stateManager core.StateManager,
+	eventBus *events.EventBus,
+	logger *slog.Logger,
+) *WorkflowExecutor {
+	return &WorkflowExecutor{
+		runnerFactory:    runnerFactory,
+		stateManager:     stateManager,
+		eventBus:         eventBus,
+		logger:           logger,
+		executionTimeout: 4 * time.Hour,
+	}
+}
+
+// WithExecutionTimeout sets the execution timeout.
+func (e *WorkflowExecutor) WithExecutionTimeout(timeout time.Duration) *WorkflowExecutor {
+	e.executionTimeout = timeout
+	return e
+}
+
+// IsRunning checks if a workflow is currently executing.
+func (e *WorkflowExecutor) IsRunning(workflowID string) bool {
+	_, exists := e.running.Load(workflowID)
+	return exists
+}
+
+// Run starts a workflow from its initial state.
+func (e *WorkflowExecutor) Run(ctx context.Context, workflowID core.WorkflowID) error {
+	return e.execute(ctx, workflowID, false)
+}
+
+// Resume continues a workflow from where it left off.
+func (e *WorkflowExecutor) Resume(ctx context.Context, workflowID core.WorkflowID) error {
+	return e.execute(ctx, workflowID, true)
+}
+
+// execute handles both run and resume operations.
+func (e *WorkflowExecutor) execute(ctx context.Context, workflowID core.WorkflowID, isResume bool) error {
+	id := string(workflowID)
+
+	// Load workflow state
+	state, err := e.stateManager.LoadByID(ctx, workflowID)
+	if err != nil {
+		return fmt.Errorf("loading workflow: %w", err)
+	}
+	if state == nil {
+		return fmt.Errorf("workflow not found: %s", workflowID)
+	}
+
+	// Validate state for execution
+	switch state.Status {
+	case core.WorkflowStatusRunning:
+		return fmt.Errorf("workflow is already running")
+	case core.WorkflowStatusCompleted:
+		return fmt.Errorf("workflow is already completed")
+	case core.WorkflowStatusPending, core.WorkflowStatusFailed, core.WorkflowStatusPaused:
+		// OK to execute
+	default:
+		return fmt.Errorf("workflow is in invalid state: %s", state.Status)
+	}
+
+	// Prevent double-execution
+	if _, loaded := e.running.LoadOrStore(id, true); loaded {
+		return fmt.Errorf("workflow execution already in progress")
+	}
+
+	// Check runner factory
+	if e.runnerFactory == nil {
+		e.running.Delete(id)
+		return fmt.Errorf("workflow execution not available: missing configuration")
+	}
+
+	// Create execution context
+	execCtx, cancel := context.WithTimeout(context.Background(), e.executionTimeout)
+
+	// Create ControlPlane for this workflow
+	cp := control.New()
+	e.controlPlanes.Store(id, cp)
+
+	// Create runner
+	runner, notifier, err := e.runnerFactory.CreateRunner(execCtx, id, cp)
+	if err != nil {
+		cancel()
+		e.controlPlanes.Delete(id)
+		e.running.Delete(id)
+		return fmt.Errorf("creating runner: %w", err)
+	}
+
+	// Connect notifier to state for agent event persistence
+	notifier.SetState(state)
+	notifier.SetStateSaver(e.stateManager)
+
+	// Update status to running
+	state.Status = core.WorkflowStatusRunning
+	state.Error = ""
+	state.UpdatedAt = time.Now()
+	now := time.Now().UTC()
+	state.HeartbeatAt = &now
+
+	if err := e.stateManager.Save(ctx, state); err != nil {
+		cancel()
+		e.controlPlanes.Delete(id)
+		e.running.Delete(id)
+		return fmt.Errorf("saving workflow state: %w", err)
+	}
+
+	// Start execution in background
+	go e.executeAsync(execCtx, cancel, runner, notifier, state, isResume, id)
+
+	return nil
+}
+
+// executeAsync runs the workflow in a background goroutine.
+func (e *WorkflowExecutor) executeAsync(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	runner *workflow.Runner,
+	notifier interface {
+		WorkflowStarted(prompt string)
+		WorkflowCompleted(duration time.Duration, totalCost float64)
+		WorkflowFailed(phase string, err error)
+		FlushState()
+	},
+	state *core.WorkflowState,
+	isResume bool,
+	workflowID string,
+) {
+	defer cancel()
+	defer e.running.Delete(workflowID)
+	defer e.controlPlanes.Delete(workflowID)
+	defer notifier.FlushState()
+
+	// Emit workflow started event
+	notifier.WorkflowStarted(state.Prompt)
+
+	startTime := time.Now()
+	var runErr error
+
+	// Execute workflow
+	if isResume {
+		runErr = runner.ResumeWithState(ctx, state)
+	} else {
+		runErr = runner.RunWithState(ctx, state)
+	}
+
+	// Get final state for metrics
+	finalState, _ := runner.GetState(ctx)
+	duration := time.Since(startTime)
+	var totalCost float64
+	if finalState != nil && finalState.Metrics != nil {
+		totalCost = finalState.Metrics.TotalCostUSD
+	}
+
+	// Emit lifecycle event
+	if runErr != nil {
+		e.logger.Error("workflow execution failed",
+			"workflow_id", state.WorkflowID,
+			"error", runErr,
+		)
+		notifier.WorkflowFailed(string(state.CurrentPhase), runErr)
+
+		// Publish SSE event
+		if e.eventBus != nil {
+			e.eventBus.Publish(events.NewWorkflowFailedEvent(workflowID, string(state.CurrentPhase), runErr))
+		}
+	} else {
+		e.logger.Info("workflow execution completed",
+			"workflow_id", state.WorkflowID,
+			"duration", duration,
+			"cost", totalCost,
+		)
+		notifier.WorkflowCompleted(duration, totalCost)
+
+		// Publish SSE event
+		if e.eventBus != nil {
+			e.eventBus.Publish(events.NewWorkflowCompletedEvent(workflowID, duration, totalCost))
+		}
+	}
+}
+
+// GetControlPlane returns the control plane for a running workflow.
+func (e *WorkflowExecutor) GetControlPlane(workflowID string) (*control.ControlPlane, bool) {
+	if cp, ok := e.controlPlanes.Load(workflowID); ok {
+		return cp.(*control.ControlPlane), true
+	}
+	return nil, false
+}
+
+// Cancel cancels a running workflow.
+func (e *WorkflowExecutor) Cancel(workflowID string) error {
+	cp, ok := e.GetControlPlane(workflowID)
+	if !ok {
+		return fmt.Errorf("workflow is not running")
+	}
+	if cp.IsCancelled() {
+		return fmt.Errorf("workflow is already being cancelled")
+	}
+	cp.Cancel()
+	e.logger.Info("workflow cancellation requested", "workflow_id", workflowID)
+	return nil
+}
+
+// Pause pauses a running workflow.
+func (e *WorkflowExecutor) Pause(workflowID string) error {
+	cp, ok := e.GetControlPlane(workflowID)
+	if !ok {
+		return fmt.Errorf("workflow is not running")
+	}
+	if cp.IsPaused() {
+		return fmt.Errorf("workflow is already paused")
+	}
+	cp.Pause()
+	e.logger.Info("workflow pause requested", "workflow_id", workflowID)
+	return nil
+}
+
+// StateManager returns the state manager for external use.
+func (e *WorkflowExecutor) StateManager() core.StateManager {
+	return e.stateManager
+}
+
+// EventBus returns the event bus for external use.
+func (e *WorkflowExecutor) EventBus() *events.EventBus {
+	return e.eventBus
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hugo-lorenzo-mato/quorum-ai/internal/core"
 	"github.com/hugo-lorenzo-mato/quorum-ai/internal/diagnostics"
 	"github.com/hugo-lorenzo-mato/quorum-ai/internal/events"
+	"github.com/hugo-lorenzo-mato/quorum-ai/internal/service/workflow"
 )
 
 // Server provides HTTP REST API endpoints for workflow management.
@@ -39,6 +40,12 @@ type Server struct {
 	// Control planes for running workflows (enables pause/resume/cancel)
 	controlPlanesMu sync.RWMutex
 	controlPlanes   map[string]*control.ControlPlane
+
+	// Workflow executor for centralized execution management
+	executor *WorkflowExecutor
+
+	// Heartbeat manager for zombie workflow detection
+	heartbeat *workflow.HeartbeatManager
 }
 
 // ServerOption configures the server.
@@ -76,6 +83,20 @@ func WithConfigLoader(loader *config.Loader) ServerOption {
 func WithRoot(root string) ServerOption {
 	return func(s *Server) {
 		s.root = root
+	}
+}
+
+// WithWorkflowExecutor sets the workflow executor for centralized execution management.
+func WithWorkflowExecutor(executor *WorkflowExecutor) ServerOption {
+	return func(s *Server) {
+		s.executor = executor
+	}
+}
+
+// WithHeartbeatManager sets the heartbeat manager for zombie workflow detection.
+func WithHeartbeatManager(hb *workflow.HeartbeatManager) ServerOption {
+	return func(s *Server) {
+		s.heartbeat = hb
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,11 +94,28 @@ type PreflightConfig struct {
 
 // WorkflowConfig configures workflow execution.
 type WorkflowConfig struct {
-	Timeout    string   `mapstructure:"timeout"`
-	MaxRetries int      `mapstructure:"max_retries"`
-	DryRun     bool     `mapstructure:"dry_run"`
-	Sandbox    bool     `mapstructure:"sandbox"`
-	DenyTools  []string `mapstructure:"deny_tools"`
+	Timeout    string          `mapstructure:"timeout"`
+	MaxRetries int             `mapstructure:"max_retries"`
+	DryRun     bool            `mapstructure:"dry_run"`
+	Sandbox    bool            `mapstructure:"sandbox"`
+	DenyTools  []string        `mapstructure:"deny_tools"`
+	Heartbeat  HeartbeatConfig `mapstructure:"heartbeat"`
+}
+
+// HeartbeatConfig configures the heartbeat system for zombie workflow detection.
+type HeartbeatConfig struct {
+	// Enabled activates the heartbeat system.
+	Enabled bool `mapstructure:"enabled"`
+	// Interval is how often to write heartbeats (e.g., "30s").
+	Interval string `mapstructure:"interval"`
+	// StaleThreshold is when to consider a workflow zombie (e.g., "2m").
+	StaleThreshold string `mapstructure:"stale_threshold"`
+	// CheckInterval is how often to check for zombies (e.g., "60s").
+	CheckInterval string `mapstructure:"check_interval"`
+	// AutoResume enables automatic resume of zombie workflows.
+	AutoResume bool `mapstructure:"auto_resume"`
+	// MaxResumes is the maximum auto-resume attempts per workflow.
+	MaxResumes int `mapstructure:"max_resumes"`
 }
 
 // PhasesConfig configures each workflow phase.

--- a/internal/service/workflow/heartbeat.go
+++ b/internal/service/workflow/heartbeat.go
@@ -1,0 +1,318 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/hugo-lorenzo-mato/quorum-ai/internal/core"
+)
+
+// HeartbeatConfig configures the heartbeat system.
+type HeartbeatConfig struct {
+	// Interval is how often to write heartbeats (default: 30s)
+	Interval time.Duration
+
+	// StaleThreshold is when to consider a workflow zombie (default: 2m)
+	StaleThreshold time.Duration
+
+	// CheckInterval is how often to check for zombies (default: 60s)
+	CheckInterval time.Duration
+
+	// AutoResume enables automatic resume of zombie workflows
+	AutoResume bool
+
+	// MaxResumes is the maximum auto-resume attempts per workflow (default: 3)
+	MaxResumes int
+}
+
+// DefaultHeartbeatConfig returns the default heartbeat configuration.
+func DefaultHeartbeatConfig() HeartbeatConfig {
+	return HeartbeatConfig{
+		Interval:       30 * time.Second,
+		StaleThreshold: 2 * time.Minute,
+		CheckInterval:  60 * time.Second,
+		AutoResume:     false,
+		MaxResumes:     3,
+	}
+}
+
+// ZombieHandler is called when a zombie workflow is detected.
+type ZombieHandler func(state *core.WorkflowState)
+
+// HeartbeatManager manages heartbeats for running workflows and detects zombies.
+type HeartbeatManager struct {
+	config       HeartbeatConfig
+	stateManager core.StateManager
+	logger       *slog.Logger
+
+	// Track active heartbeat goroutines
+	mu     sync.Mutex
+	active map[core.WorkflowID]context.CancelFunc
+
+	// Zombie detector
+	detectorCancel context.CancelFunc
+	zombieHandler  ZombieHandler
+}
+
+// NewHeartbeatManager creates a new heartbeat manager.
+func NewHeartbeatManager(
+	config HeartbeatConfig,
+	stateManager core.StateManager,
+	logger *slog.Logger,
+) *HeartbeatManager {
+	return &HeartbeatManager{
+		config:       config,
+		stateManager: stateManager,
+		logger:       logger,
+		active:       make(map[core.WorkflowID]context.CancelFunc),
+	}
+}
+
+// Config returns the current configuration.
+func (h *HeartbeatManager) Config() HeartbeatConfig {
+	return h.config
+}
+
+// Start begins heartbeat tracking for a workflow.
+func (h *HeartbeatManager) Start(workflowID core.WorkflowID) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	// If already tracking, do nothing
+	if _, exists := h.active[workflowID]; exists {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	h.active[workflowID] = cancel
+
+	go h.heartbeatLoop(ctx, workflowID)
+
+	h.logger.Debug("started heartbeat tracking", "workflow_id", workflowID)
+}
+
+// Stop ends heartbeat tracking for a workflow.
+func (h *HeartbeatManager) Stop(workflowID core.WorkflowID) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if cancel, exists := h.active[workflowID]; exists {
+		cancel()
+		delete(h.active, workflowID)
+		h.logger.Debug("stopped heartbeat tracking", "workflow_id", workflowID)
+	}
+}
+
+// IsTracking checks if a workflow is being tracked.
+func (h *HeartbeatManager) IsTracking(workflowID core.WorkflowID) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	_, exists := h.active[workflowID]
+	return exists
+}
+
+// heartbeatLoop writes heartbeats periodically until stopped.
+func (h *HeartbeatManager) heartbeatLoop(ctx context.Context, workflowID core.WorkflowID) {
+	ticker := time.NewTicker(h.config.Interval)
+	defer ticker.Stop()
+
+	// Write initial heartbeat
+	h.writeHeartbeat(workflowID)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			h.writeHeartbeat(workflowID)
+		}
+	}
+}
+
+// writeHeartbeat updates the heartbeat timestamp in the database.
+func (h *HeartbeatManager) writeHeartbeat(workflowID core.WorkflowID) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := h.stateManager.UpdateHeartbeat(ctx, workflowID); err != nil {
+		h.logger.Warn("failed to write heartbeat",
+			"workflow_id", workflowID,
+			"error", err)
+	}
+}
+
+// StartZombieDetector begins periodic zombie detection.
+func (h *HeartbeatManager) StartZombieDetector(handler ZombieHandler) {
+	if handler == nil {
+		h.logger.Warn("zombie detector started without handler")
+		return
+	}
+
+	h.zombieHandler = handler
+
+	ctx, cancel := context.WithCancel(context.Background())
+	h.detectorCancel = cancel
+
+	go h.zombieDetectorLoop(ctx)
+
+	h.logger.Info("zombie detector started",
+		"check_interval", h.config.CheckInterval,
+		"stale_threshold", h.config.StaleThreshold,
+		"auto_resume", h.config.AutoResume)
+}
+
+// StopZombieDetector stops the zombie detector.
+func (h *HeartbeatManager) StopZombieDetector() {
+	if h.detectorCancel != nil {
+		h.detectorCancel()
+		h.detectorCancel = nil
+		h.logger.Info("zombie detector stopped")
+	}
+}
+
+// zombieDetectorLoop checks for zombie workflows periodically.
+func (h *HeartbeatManager) zombieDetectorLoop(ctx context.Context) {
+	ticker := time.NewTicker(h.config.CheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			h.detectZombies()
+		}
+	}
+}
+
+// detectZombies finds and handles zombie workflows.
+func (h *HeartbeatManager) detectZombies() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	zombies, err := h.stateManager.FindZombieWorkflows(ctx, h.config.StaleThreshold)
+	if err != nil {
+		h.logger.Error("failed to find zombie workflows", "error", err)
+		return
+	}
+
+	for _, zombie := range zombies {
+		// Skip if we're actively tracking this workflow (heartbeat write failed but still alive)
+		if h.IsTracking(zombie.WorkflowID) {
+			continue
+		}
+
+		h.logger.Warn("zombie workflow detected",
+			"workflow_id", zombie.WorkflowID,
+			"phase", zombie.CurrentPhase,
+			"heartbeat_at", zombie.HeartbeatAt)
+
+		if h.zombieHandler != nil {
+			h.zombieHandler(zombie)
+		}
+	}
+}
+
+// HandleZombie processes a detected zombie workflow.
+// This is the default handler that can be used or customized.
+func (h *HeartbeatManager) HandleZombie(state *core.WorkflowState, executor interface {
+	Resume(ctx context.Context, workflowID core.WorkflowID) error
+}) {
+	ctx := context.Background()
+
+	// Check if we can auto-resume
+	canResume := h.config.AutoResume &&
+		state.ResumeCount < state.MaxResumes &&
+		state.MaxResumes > 0
+
+	if canResume {
+		h.logger.Info("auto-resuming zombie workflow",
+			"workflow_id", state.WorkflowID,
+			"resume_count", state.ResumeCount+1,
+			"max_resumes", state.MaxResumes)
+
+		// Increment resume count
+		state.ResumeCount++
+		now := time.Now()
+		state.HeartbeatAt = &now
+		state.UpdatedAt = now
+
+		// Add checkpoint explaining the auto-resume
+		state.Checkpoints = append(state.Checkpoints, core.Checkpoint{
+			ID:        fmt.Sprintf("auto-resume-%d", time.Now().UnixNano()),
+			Type:      "auto-resume",
+			Phase:     state.CurrentPhase,
+			Timestamp: now,
+			Message: fmt.Sprintf("Auto-resumed after detecting stale heartbeat (attempt %d/%d)",
+				state.ResumeCount, state.MaxResumes),
+		})
+
+		// Save updated state
+		if err := h.stateManager.Save(ctx, state); err != nil {
+			h.logger.Error("failed to save state before auto-resume",
+				"workflow_id", state.WorkflowID,
+				"error", err)
+			return
+		}
+
+		// Trigger resume
+		if executor != nil {
+			if err := executor.Resume(ctx, state.WorkflowID); err != nil {
+				h.logger.Error("auto-resume failed",
+					"workflow_id", state.WorkflowID,
+					"error", err)
+			}
+		}
+
+	} else {
+		// Can't resume - mark as failed
+		reason := "Zombie workflow detected (stale heartbeat)"
+		if state.MaxResumes > 0 && state.ResumeCount >= state.MaxResumes {
+			reason = fmt.Sprintf("Max auto-resumes reached (%d/%d)", state.ResumeCount, state.MaxResumes)
+		} else if !h.config.AutoResume {
+			reason = "Zombie workflow detected (auto-resume disabled)"
+		}
+
+		h.logger.Warn("marking zombie workflow as failed",
+			"workflow_id", state.WorkflowID,
+			"reason", reason)
+
+		state.Status = core.WorkflowStatusFailed
+		state.Error = reason
+		state.UpdatedAt = time.Now()
+
+		state.Checkpoints = append(state.Checkpoints, core.Checkpoint{
+			ID:        fmt.Sprintf("zombie-%d", time.Now().UnixNano()),
+			Type:      "zombie_detected",
+			Phase:     state.CurrentPhase,
+			Timestamp: time.Now(),
+			Message:   reason,
+		})
+
+		if err := h.stateManager.Save(ctx, state); err != nil {
+			h.logger.Error("failed to save zombie state",
+				"workflow_id", state.WorkflowID,
+				"error", err)
+		}
+	}
+}
+
+// Shutdown stops all heartbeat tracking and the zombie detector.
+func (h *HeartbeatManager) Shutdown() {
+	// Stop zombie detector
+	h.StopZombieDetector()
+
+	// Stop all active heartbeats
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	for workflowID, cancel := range h.active {
+		cancel()
+		delete(h.active, workflowID)
+	}
+
+	h.logger.Info("heartbeat manager shutdown complete")
+}


### PR DESCRIPTION
## Summary

Implement cross-platform zombie workflow detection using SQLite timestamps. Workflows that crash or become unresponsive are detected via stale heartbeat and can be automatically resumed.

Closes #260

## Changes

- Add `HeartbeatAt`, `ResumeCount`, `MaxResumes` fields to WorkflowState
- Add `UpdateHeartbeat` and `FindZombieWorkflows` to StateManager interface
- Create `HeartbeatManager` for per-workflow heartbeat goroutines
- Create `WorkflowExecutor` for centralized execution management
- Add heartbeat configuration section in config
- Expose `heartbeat_at` in API response
- Update default agent timeout from 5min to 3h

## Configuration

```yaml
workflow:
  heartbeat:
    enabled: true
    interval: "30s"
    stale_threshold: "2m"
    check_interval: "1m"
    auto_resume: true
    max_resumes: 3
```

## Test Plan

- [x] `make check` passes
- [x] All unit tests pass
- [x] Frontend builds successfully
- [ ] Manual test: Start workflow, kill server, restart, verify zombie detection
- [ ] Manual test: Verify auto-resume increments resume_count
- [ ] Manual test: Verify max_resumes limit marks workflow as failed