### PR TITLE
feat(quorum): Per-Workflow Locking Mechanism

### DIFF
--- a/internal/adapters/state/json.go
+++ b/internal/adapters/state/json.go
@@ -853,5 +853,53 @@ func (m *JSONStateManager) FindZombieWorkflows(ctx context.Context, staleThresho
 	return zombies, nil
 }
 
+// AcquireWorkflowLock acquires an exclusive lock for a specific workflow.
+// JSONStateManager uses file-based locking and delegates to the global lock.
+func (m *JSONStateManager) AcquireWorkflowLock(ctx context.Context, workflowID core.WorkflowID) error {
+	// JSON state manager uses single-file storage, so per-workflow locking
+	// falls back to global locking for simplicity.
+	return m.AcquireLock(ctx)
+}
+
+// ReleaseWorkflowLock releases the lock for a specific workflow.
+func (m *JSONStateManager) ReleaseWorkflowLock(ctx context.Context, workflowID core.WorkflowID) error {
+	return m.ReleaseLock(ctx)
+}
+
+// RefreshWorkflowLock extends the lock expiration time for a workflow.
+// For JSON state manager, this is a no-op since file-based locks don't expire actively.
+func (m *JSONStateManager) RefreshWorkflowLock(_ context.Context, _ core.WorkflowID) error {
+	return nil
+}
+
+// SetWorkflowRunning marks a workflow as currently executing.
+// For JSON state manager, this is tracked only in memory.
+func (m *JSONStateManager) SetWorkflowRunning(_ context.Context, _ core.WorkflowID) error {
+	return nil // No-op for JSON state manager
+}
+
+// ClearWorkflowRunning removes a workflow from the running state.
+func (m *JSONStateManager) ClearWorkflowRunning(_ context.Context, _ core.WorkflowID) error {
+	return nil // No-op for JSON state manager
+}
+
+// ListRunningWorkflows returns IDs of all currently executing workflows.
+// For JSON state manager, this returns an empty list since running state is not tracked.
+func (m *JSONStateManager) ListRunningWorkflows(_ context.Context) ([]core.WorkflowID, error) {
+	return nil, nil
+}
+
+// IsWorkflowRunning checks if a specific workflow is currently executing.
+// For JSON state manager, this always returns false since running state is not tracked.
+func (m *JSONStateManager) IsWorkflowRunning(_ context.Context, _ core.WorkflowID) (bool, error) {
+	return false, nil
+}
+
+// UpdateWorkflowHeartbeat updates the heartbeat timestamp for a running workflow.
+// For JSON state manager, this is a no-op.
+func (m *JSONStateManager) UpdateWorkflowHeartbeat(_ context.Context, _ core.WorkflowID) error {
+	return nil
+}
+
 // Verify that JSONStateManager implements core.StateManager.
 var _ core.StateManager = (*JSONStateManager)(nil)

--- a/internal/core/ports.go
+++ b/internal/core/ports.go
@@ -166,7 +166,35 @@ type StateManager interface {
 	AcquireLock(ctx context.Context) error
 
 	// ReleaseLock releases the exclusive lock.
+	// DEPRECATED: Use ReleaseWorkflowLock for per-workflow locking.
 	ReleaseLock(ctx context.Context) error
+
+	// AcquireWorkflowLock obtains an exclusive lock for a specific workflow.
+	// Returns error if lock cannot be acquired (another process holds it).
+	AcquireWorkflowLock(ctx context.Context, workflowID WorkflowID) error
+
+	// ReleaseWorkflowLock releases the lock for a specific workflow.
+	ReleaseWorkflowLock(ctx context.Context, workflowID WorkflowID) error
+
+	// RefreshWorkflowLock extends the lock expiration time for a workflow.
+	// Returns error if the lock is not held by this process.
+	RefreshWorkflowLock(ctx context.Context, workflowID WorkflowID) error
+
+	// SetWorkflowRunning marks a workflow as currently executing.
+	SetWorkflowRunning(ctx context.Context, workflowID WorkflowID) error
+
+	// ClearWorkflowRunning removes a workflow from the running state.
+	ClearWorkflowRunning(ctx context.Context, workflowID WorkflowID) error
+
+	// ListRunningWorkflows returns IDs of all currently executing workflows.
+	ListRunningWorkflows(ctx context.Context) ([]WorkflowID, error)
+
+	// IsWorkflowRunning checks if a specific workflow is currently executing.
+	IsWorkflowRunning(ctx context.Context, workflowID WorkflowID) (bool, error)
+
+	// UpdateWorkflowHeartbeat updates the heartbeat timestamp for a running workflow.
+	// Used to prove liveness - workflows with stale heartbeats are considered dead.
+	UpdateWorkflowHeartbeat(ctx context.Context, workflowID WorkflowID) error
 
 	// Exists checks if state file exists.
 	Exists() bool


### PR DESCRIPTION
## Summary
- Implements per-workflow locking to prevent concurrent modifications
- Adds workflow locking tables and SQLite adapter methods
- Includes comprehensive tests (+345 lines)
- Part of workflow `wf-20260129-193906-s3l6i`

## Test plan
- [ ] Run `go test ./internal/adapters/state/...`
- [ ] Verify locking prevents race conditions

🤖 Generated with [Quorum AI](https://github.com/hugo-lorenzo-mato/quorum-ai)